### PR TITLE
PHPUnit 5 limit (task #3311)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Plugin to add brand to website footer",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.4.16",
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^5.0",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
* Limit PHPUnit to version 5 to avoid PHP5/7 incompatibility introduced by PHPUnit 6.
* Removed dependency checking for PHP since it's already handled by CakePHP.